### PR TITLE
Properly handle setuid programs on WSL

### DIFF
--- a/notes/Guix-on-WSL2.md
+++ b/notes/Guix-on-WSL2.md
@@ -487,6 +487,15 @@ export GUIX_NEW_SYSTEM=$(/busybox readlink -f /var/guix/profiles/system)
 /var/guix/profiles/system/profile/bin/guile --no-auto-compile $GUIX_NEW_SYSTEM/boot &
 
 /busybox sleep 3
+
+# WSL mounts /run with the noexec and nosuid mount flags, preventing the
+# binaries in /run/setuid-programs from being useful. As a workaround, we can
+# copy those binaries to /var/run/setuid-programs and bind-mount on top.
+/busybox rm -rf /var/run/setuid-programs
+/busybox mkdir -p /var/run/setuid-programs
+/busybox cp -p /run/setuid-programs/* /var/run/setuid-programs/
+/busybox mount -o bind /var/run/setuid-programs /run/setuid-programs
+
 source /etc/profile
 
 # why are these permissions not there in the first place?

--- a/notes/Guix-on-WSL2.md
+++ b/notes/Guix-on-WSL2.md
@@ -498,11 +498,6 @@ export GUIX_NEW_SYSTEM=$(/busybox readlink -f /var/guix/profiles/system)
 
 source /etc/profile
 
-# why are these permissions not there in the first place?
-for f in ping su sudo; do
-        chmod 4755 $(readlink -f $(which $f))
-done
-
 su -l giuliano -c tmux
 
 bash


### PR DESCRIPTION
WSL mounts /run with the noexec and nosuid mount flags, preventing /run/setuid-programs from being executed setuid (in fact, they can't be executed whatsoever from that location).

The existing workaround to allow setuid usage of `ping`, `su`, and `sudo` is insufficiently general. I also suspect that it modifies the contents of packages within /gnu/store (a directory [intended to be immutable][1] except to the guix daemon).

As a replacement for the existing workaround, this change copies the setuid programs into a directory under /var/run and uses a bind mount to make /run/setuid-programs work as expected.

[1]: <https://guix.gnu.org/en/manual/en/html_node/The-Store.html#The-Store>